### PR TITLE
feat: dump local filename and checksums in addition to repository URLs

### DIFF
--- a/src/java/org/apache/ivy/Main.java
+++ b/src/java/org/apache/ivy/Main.java
@@ -369,7 +369,7 @@ public final class Main {
                                     "ivy-[revision].xml")))
                             .setOverwrite(line.hasOption("overwrite"))
                             .setExportDestination(line.hasOption("exportdestination"),
-                                                  line.getOptionValue("exportdestination", "ivyartifactdestination.txt")));
+                                                  line.getOptionValue("exportdestination", "ivyartifactdestination.yml")));
             }
         }
         if (line.hasOption("main")) {

--- a/version.properties
+++ b/version.properties
@@ -16,9 +16,9 @@
 #	 * specific language governing permissions and limitations
 #	 * under the License.
 #	 ***************************************************************
-target.ivy.version=2.5.2
+target.ivy.version=2.5.3
 # Following OSGi spec: have to be 3 numbers separated by dots
-target.ivy.bundle.version=2.5.2
+target.ivy.bundle.version=2.5.3
 # in case we want to add a qualifier such as alpha, beta, etc...
 # if non empty, add a '_' at the end of the qualifier, so the version would look like 1.2.3.alpha_200901011200
 target.ivy.bundle.version.qualifier=alpha_


### PR DESCRIPTION
BREAKING CHANGE: this changes the output file format to YAML
This change of output format accommodates having more than a single
field per entry.

In addition to the destination URL we now provide the local file's path
and several checksums of its content. This extra meta data should
facilitate aggregating these artifacts' into "builds" in Artifactory.
This facilitates it in a way that doesn't depend on the absence of race
conditions between the time of upload through Ivy and the time that the
"build info" gets created.

<del>Note, this PR is (currently) only intended to gather review feedback. I have not yet completed testing.</del>

This is the form of the output:
```yaml
- {file: 'build-x86/stacktrace-0.1.2+g2d28368-Linux-x86_64.tar.gz', url: 'https://example.com/artifactory/pkg-download/com.example.stacktrace/Stacktrace-0.1.2+g2d28368-Linux-x86_64.tar.gz', md5: ca4c2c612f865e8145a33f9692483392, sha1: 4ca9f0d7edf40e06d6bbfcb5259b1edd578aea07, SHA-256: f0afc0356734442bc2c9952198c887109ccbfa7df1b9ec54ba34b76e426ffbbc,}
- {file: 'build-aarch64/stacktrace-0.1.2+g2d28368-Linux-aarch64.tar.gz', url: 'https://example.com/artifactory/pkg-download/com.example.stacktrace/Stacktrace-0.1.2+g2d28368-Linux-aarch64.tar.gz', md5: 6456b4be01f905ef194b3df268324353, sha1: 3794dc66a11b27870d2ca4c2a267faa6b0ee3ee6, SHA-256: dbbd8fadc4adba28b785f945e3706cf293b2a0f3c9ca42740cc3b1ee8e8d028b,}
```